### PR TITLE
Enable CORS headers

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6,7 +6,17 @@ const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 3001;
 
-app.use(cors());
+// Explicitly enable CORS for all origins. While `cors()` without
+// options already allows any origin, some hosting providers may not
+// respect the default configuration. By specifying the origin we ensure
+// the `Access-Control-Allow-Origin` header is always set.
+const corsOptions = {
+  origin: '*',
+};
+
+app.use(cors(corsOptions));
+// Support pre-flight requests
+app.options('*', cors(corsOptions));
 
 const dataPath = path.join(__dirname, 'data', 'teams8.json');
 


### PR DESCRIPTION
## Summary
- explicitly enable CORS in Express backend

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_687d2488efe48327acdaa25de440090b